### PR TITLE
Example compat with Python 2.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -58,6 +58,7 @@ Usage
 
  import sense2vec
  model = sense2vec.load()
+ from __future__ import unicode_literals
  freq, query_vector = model["natural_language_processing|NOUN"]
  model.most_similar(query_vector, n=3)
 


### PR DESCRIPTION
In the examples spaCy uses Python 3-style strings, which won't work at the same time in Python 2.