### PR TITLE
Specify UTF-8 encoding when opening README.rst

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -103,7 +103,7 @@ def setup_package():
             about = {}
             exec(f.read(), about)
 
-        with open(os.path.join(root, 'README.rst')) as f:
+        with open(os.path.join(root, 'README.rst'), encoding='utf-8') as f:
             readme = f.read()
 
         include_dirs = [


### PR DESCRIPTION
When I run `pip install sense2vec`, I get this error:
```
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-install-rn703tob/spacy/setup.py", line 225, in <module>
        setup_package()
      File "/tmp/pip-install-rn703tob/spacy/setup.py", line 160, in setup_package
        readme = f.read()
      File "/home/jonah/.conda/envs/similar-sentences/lib/python3.6/encodings/ascii.py", line 26, in decode
        return codecs.ascii_decode(input, self.errors)[0]
    UnicodeDecodeError: 'ascii' codec can't decode byte 0xc3 in position 2680: ordinal not in range(128)
    
    ----------------------------------------
Command "python setup.py egg_info" failed with error code 1 in /tmp/pip-install-rn703tob/spacy/
```
Specifying the encoding when opening README.rst seems to fix the problem for me.