### PR TITLE
set Force=True on all set_extensions

### DIFF
--- a/sense2vec/__init__.py
+++ b/sense2vec/__init__.py
@@ -58,14 +58,14 @@ class Sense2VecComponent(object):
         # even if the component is only created and not added
         Token = doc[0].__class__
         Span = doc[:1].__class__
-        Token.set_extension('in_s2v', getter=lambda t: self.in_s2v(t))
-        Token.set_extension('s2v_freq', getter=lambda t: self.s2v_freq(t))
-        Token.set_extension('s2v_vec', getter=lambda t: self.s2v_vec(t))
-        Token.set_extension('s2v_most_similar', method=lambda t, n: self.s2v_most_sim(t, n))
-        Span.set_extension('in_s2v', getter=lambda s: self.in_s2v(s, 'ent'))
-        Span.set_extension('s2v_freq', getter=lambda s: self.s2v_freq(s, 'ent'))
-        Span.set_extension('s2v_vec', getter=lambda s: self.s2v_vec(s, 'ent'))
-        Span.set_extension('s2v_most_similar', method=lambda s, n: self.s2v_most_sim(s, n, 'ent'))
+        Token.set_extension('in_s2v', getter=lambda t: self.in_s2v(t), force=True)
+        Token.set_extension('s2v_freq', getter=lambda t: self.s2v_freq(t), force=True)
+        Token.set_extension('s2v_vec', getter=lambda t: self.s2v_vec(t), force=True)
+        Token.set_extension('s2v_most_similar', method=lambda t, n: self.s2v_most_sim(t, n), force=True)
+        Span.set_extension('in_s2v', getter=lambda s: self.in_s2v(s, 'ent'), force=True)
+        Span.set_extension('s2v_freq', getter=lambda s: self.s2v_freq(s, 'ent'), force=True)
+        Span.set_extension('s2v_vec', getter=lambda s: self.s2v_vec(s, 'ent'), force=True)
+        Span.set_extension('s2v_most_similar', method=lambda s, n: self.s2v_most_sim(s, n, 'ent'), force=True)
 
     def in_s2v(self, obj, attr='pos'):
         return self._get_query(obj, attr) in self.s2v

--- a/sense2vec/vectors.pyx
+++ b/sense2vec/vectors.pyx
@@ -155,6 +155,18 @@ cdef class VectorMap:
         indices, scores = self.data.most_similar(vector, n)
         return [self.strings[idx] for idx in indices], scores
 
+    def similarity(self, float[:] v1, float[:] v2):
+        '''Measure the similarity between two vectors, using cosine.
+
+        Arguments:
+            v1 float[:]
+            v2 float[:]
+
+        Returns:
+            similarity_score -1<float<=1
+        '''
+        return self.data.similarity(v1, v2)
+
     def add(self, unicode string, int freq, float[:] vector):
         '''Insert a vector into the map by value. Makes a copy of the vector.
         '''

--- a/sense2vec/vectors.pyx
+++ b/sense2vec/vectors.pyx
@@ -313,7 +313,7 @@ cdef class VectorStore:
         for i in range(nr_vector):
             cfile.read_into(&tmp[0], self.nr_dim, sizeof(tmp[0]))
             ptr = &tmp[0]
-            cv = <float[:128]>ptr
+            cv = <float[:nr_dim]>ptr
             if i >= 1:
                 self.add(cv)
         cfile.close()

--- a/sense2vec/vectors.pyx
+++ b/sense2vec/vectors.pyx
@@ -313,7 +313,7 @@ cdef class VectorStore:
         for i in range(nr_vector):
             cfile.read_into(&tmp[0], self.nr_dim, sizeof(tmp[0]))
             ptr = &tmp[0]
-            cv = <float[:nr_dim]>ptr
+            cv = <float[:self.nr_dim]>ptr
             if i >= 1:
                 self.add(cv)
         cfile.close()


### PR DESCRIPTION
to avoid errors like "Extension 'in_s2v' already exists on Token" when multiple spacy+sense2vec pipelines are loaded in the same process (e.g. when creating the spacy+sense2vec pipeline in a mapPartitions call in spark)