### PR TITLE
Fix hardcoded 128 dimensions

### DIFF
--- a/sense2vec/vectors.pyx
+++ b/sense2vec/vectors.pyx
@@ -313,7 +313,7 @@ cdef class VectorStore:
         for i in range(nr_vector):
             cfile.read_into(&tmp[0], self.nr_dim, sizeof(tmp[0]))
             ptr = &tmp[0]
-            cv = <float[:128]>ptr
+            cv = <float[:nr_dim]>ptr
             if i >= 1:
                 self.add(cv)
         cfile.close()

--- a/sense2vec/vectors.pyx
+++ b/sense2vec/vectors.pyx
@@ -313,7 +313,7 @@ cdef class VectorStore:
         for i in range(nr_vector):
             cfile.read_into(&tmp[0], self.nr_dim, sizeof(tmp[0]))
             ptr = &tmp[0]
-            cv = <float[:nr_dim]>ptr
+            cv = <float[:self.nr_dim]>ptr
             if i >= 1:
                 self.add(cv)
         cfile.close()


### PR DESCRIPTION
I got an AssertionError when I used sense2vec with a word vector model of 300 dimensions, the root cause was that somewhere the 128 dimensions are hardcoded