### PR TITLE
Prodigy recipe for evaluating vectors

### DIFF
--- a/README.md
+++ b/README.md
@@ -601,6 +601,46 @@ prodigy sense2vec.to-patterns tech_phrases en_core_web_sm TECHNOLOGY
 --output-file /path/to/patterns.jsonl
 ```
 
+### <kbd>recipe</kbd> `sense2vec.evaluate`
+
+Evaluate a word vectors model by asking providing questions triples: is word A
+more similar to word B, or to word C? If the human mostly agrees with the model,
+the vectors model is good. The recipe will only ask about vectors with the same
+sense and supports different example selection strategies.
+
+```bash
+prodigy sense2vec.evaluate [dataset] [vectors_path] [--strategy] [--senses]
+[--n-freq] [--threshold] [--eval-whole] [--eval-only] [--show-scores]
+```
+
+| Argument              | Type       | Description                                                                                                   |
+| --------------------- | ---------- | ------------------------------------------------------------------------------------------------------------- |
+| `dataset`             | positional | Dataset to save annotations to.                                                                               |
+| `vectors_path`        | positional | Path to pretrained sense2vec vectors.                                                                         |
+| `--strategy`, `-st`   | option     | Example selection strategy. `most similar` (default) or `random`.                                             |
+| `--senses`, `-s`      | option     | Comma-separated list of senses to limit the selection to. If not set, all senses in the vectors will be used. |
+| `--n-freq`, `-n`      | option     | Number of most frequent entries to limit to.                                                                  |
+| `--threshold`, `-t`   | option     | Minimum similarity threshold to consider examples.                                                            |
+| `--eval-whole`, `-E`  | flag       | Evaluate the whole dataset instead of the current session.                                                    |
+| `--eval-only`, `-O`   | flag       | Don't annotate, only evaluate the current dataset.                                                            |
+| `--show-scores`, `-S` | flag       | Show all scores for debugging.                                                                                |
+
+#### Strategies
+
+| Name           | Description                                                                                                                                                           |
+| -------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `most_similar` | Pick a random word from a random sense and get its most similar entries of the same sense. Ask about the similarity to the last and middle entry from that selection. |
+| `random`       | Pick a random sample of 3 words from the same random sense.                                                                                                           |
+
+#### Example
+
+```bash
+prodigy sense2vec.evaluate vectors_eval /path/to/sense2vec_vectors
+--senses NOUN,ORG,PRODUCT --threshold 0.5
+```
+
+![UI preview of sense2vec.evaluate](https://user-images.githubusercontent.com/13643239/67994212-668cf400-fc44-11e9-8fe2-bf264ae32b0a.png)
+
 ## Pretrained vectors
 
 The pretrained Reddit vectors support the following "senses", either

--- a/README.md
+++ b/README.md
@@ -685,7 +685,15 @@ This package also seamlessly integrates with the [Prodigy](https://prodi.gy)
 annotation tool and exposes recipes for using sense2vec vectors to quickly
 generate lists of multi-word phrases and bootstrap NER annotations. To use a
 recipe, `sense2vec` needs to be installed in the same environment as Prodigy.
-The following recipes are available:
+The following recipes are available – see below for more detailed docs.
+
+| Recipe                                                              | Description                                                          |
+| ------------------------------------------------------------------- | -------------------------------------------------------------------- |
+| [`sense2vec.teach`](#recipe-sense2vecteach)                         | Bootstrap a terminology list using sense2vec.                        |
+| [`sense2vec.to-patterns`](#recipe-sense2vecto-patterns)             | Convert phrases dataset to token-based match patterns.               |
+| [`sense2vec.eval`](#recipe-sense2veceval)                           | Evaluate a sense2vec model by asking about phrase triples.           |
+| [`sense2vec.eval-most-similar`](#recipe-sense2veceval-most-similar) | Evaluate a sense2vec model by correcting the most similar entries.   |
+| [`sense2vec.eval-ab`](#recipe-sense2veceval-ab)                     | Perform an A/B evaluation of two pretrained sense2vec vector models. |
 
 ### <kbd>recipe</kbd> `sense2vec.teach`
 
@@ -718,8 +726,8 @@ prodigy sense2vec.teach tech_phrases /path/to/sense2vec_vectors
 
 ### <kbd>recipe</kbd> `sense2vec.to-patterns`
 
-Convert a list of seed phrases to a list of token-based match patterns that can
-be used with
+Convert a dataset of phrases collected with `sense2vec.teach` to token-based
+match patterns that can be used with
 [spaCy's `EntityRuler`](https://spacy.io/usage/rule-based-matching#entityruler)
 or recipes like `ner.match`. If no output file is specified, the patterns are
 written to stdout. The examples are tokenized so that multi-token terms are
@@ -747,45 +755,112 @@ prodigy sense2vec.to-patterns tech_phrases en_core_web_sm TECHNOLOGY
 --output-file /path/to/patterns.jsonl
 ```
 
-### <kbd>recipe</kbd> `sense2vec.evaluate`
+### <kbd>recipe</kbd> `sense2vec.eval`
 
-Evaluate a word vectors model by asking providing questions triples: is word A
-more similar to word B, or to word C? If the human mostly agrees with the model,
-the vectors model is good. The recipe will only ask about vectors with the same
+Evaluate a sense2vec model by asking about phrase triples: is word A more
+similar to word B, or to word C? If the human mostly agrees with the model, the
+vectors model is good. The recipe will only ask about vectors with the same
 sense and supports different example selection strategies.
 
 ```bash
-prodigy sense2vec.evaluate [dataset] [vectors_path] [--strategy] [--senses]
-[--n-freq] [--threshold] [--eval-whole] [--eval-only] [--show-scores]
+prodigy sense2vec.eval [dataset] [vectors_path] [--strategy] [--senses]
+[--exclude-senses] [--n-freq] [--threshold] [--batch-size] [--eval-whole]
+[--eval-only] [--show-scores]
 ```
 
-| Argument              | Type       | Description                                                                                                   |
-| --------------------- | ---------- | ------------------------------------------------------------------------------------------------------------- |
-| `dataset`             | positional | Dataset to save annotations to.                                                                               |
-| `vectors_path`        | positional | Path to pretrained sense2vec vectors.                                                                         |
-| `--strategy`, `-st`   | option     | Example selection strategy. `most similar` (default) or `random`.                                             |
-| `--senses`, `-s`      | option     | Comma-separated list of senses to limit the selection to. If not set, all senses in the vectors will be used. |
-| `--n-freq`, `-n`      | option     | Number of most frequent entries to limit to.                                                                  |
-| `--threshold`, `-t`   | option     | Minimum similarity threshold to consider examples.                                                            |
-| `--eval-whole`, `-E`  | flag       | Evaluate the whole dataset instead of the current session.                                                    |
-| `--eval-only`, `-O`   | flag       | Don't annotate, only evaluate the current dataset.                                                            |
-| `--show-scores`, `-S` | flag       | Show all scores for debugging.                                                                                |
+| Argument                  | Type       | Description                                                                                                   |
+| ------------------------- | ---------- | ------------------------------------------------------------------------------------------------------------- |
+| `dataset`                 | positional | Dataset to save annotations to.                                                                               |
+| `vectors_path`            | positional | Path to pretrained sense2vec vectors.                                                                         |
+| `--strategy`, `-st`       | option     | Example selection strategy. `most similar` (default) or `random`.                                             |
+| `--senses`, `-s`          | option     | Comma-separated list of senses to limit the selection to. If not set, all senses in the vectors will be used. |
+| `--exclude-senses`, `-es` | option     | Comma-separated list of senses to exclude. See `prodigy_recipes.EVAL_EXCLUDE_SENSES` fro the defaults.        |
+| `--n-freq`, `-f`          | option     | Number of most frequent entries to limit to.                                                                  |
+| `--threshold`, `-t`       | option     | Minimum similarity threshold to consider examples.                                                            |
+| `--batch-size`, `-b`      | option     | Batch size to use.                                                                                            |
+| `--eval-whole`, `-E`      | flag       | Evaluate the whole dataset instead of the current session.                                                    |
+| `--eval-only`, `-O`       | flag       | Don't annotate, only evaluate the current dataset.                                                            |
+| `--show-scores`, `-S`     | flag       | Show all scores for debugging.                                                                                |
 
 #### Strategies
 
-| Name           | Description                                                                                                                                                           |
-| -------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `most_similar` | Pick a random word from a random sense and get its most similar entries of the same sense. Ask about the similarity to the last and middle entry from that selection. |
-| `random`       | Pick a random sample of 3 words from the same random sense.                                                                                                           |
+| Name                 | Description                                                                                                                                                           |
+| -------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `most_similar`       | Pick a random word from a random sense and get its most similar entries of the same sense. Ask about the similarity to the last and middle entry from that selection. |
+| `most_least_similar` | Pick a random word from a random sense and get its least similar entry and then the least similar entry of that.                                                      |
+| `random`             | Pick a random sample of 3 words from the same random sense.                                                                                                           |
 
 #### Example
 
 ```bash
-prodigy sense2vec.evaluate vectors_eval /path/to/sense2vec_vectors
+prodigy sense2vec.eval vectors_eval /path/to/sense2vec_vectors
 --senses NOUN,ORG,PRODUCT --threshold 0.5
 ```
 
-![UI preview of sense2vec.evaluate](https://user-images.githubusercontent.com/13643239/67994212-668cf400-fc44-11e9-8fe2-bf264ae32b0a.png)
+![UI preview of sense2vec.eval](https://user-images.githubusercontent.com/13643239/67994212-668cf400-fc44-11e9-8fe2-bf264ae32b0a.png)
+
+### <kbd>recipe</kbd> `sense2vec.eval-most-similar`
+
+Evaluate a vectors model by looking at the most similar entries it returns for a
+random phrase and unselecting the mistakes.
+
+```bash
+prodigy sense2vec.eval [dataset] [vectors_path] [--senses] [--exclude-senses]
+[--n-freq] [--n-similar] [--batch-size] [--eval-whole] [--eval-only]
+[--show-scores]
+```
+
+| Argument                  | Type       | Description                                                                                                   |
+| ------------------------- | ---------- | ------------------------------------------------------------------------------------------------------------- |
+| `dataset`                 | positional | Dataset to save annotations to.                                                                               |
+| `vectors_path`            | positional | Path to pretrained sense2vec vectors.                                                                         |
+| `--senses`, `-s`          | option     | Comma-separated list of senses to limit the selection to. If not set, all senses in the vectors will be used. |
+| `--exclude-senses`, `-es` | option     | Comma-separated list of senses to exclude. See `prodigy_recipes.EVAL_EXCLUDE_SENSES` fro the defaults.        |
+| `--n-freq`, `-f`          | option     | Number of most frequent entries to limit to.                                                                  |
+| `--n-similar`, `-n`       | option     | Number of similar items to check. Defaults to `10`.                                                           |
+| `--batch-size`, `-b`      | option     | Batch size to use.                                                                                            |
+| `--eval-whole`, `-E`      | flag       | Evaluate the whole dataset instead of the current session.                                                    |
+| `--eval-only`, `-O`       | flag       | Don't annotate, only evaluate the current dataset.                                                            |
+| `--show-scores`, `-S`     | flag       | Show all scores for debugging.                                                                                |
+
+```bash
+prodigy sense2vec.eval-most-similar vectors_eval_sim /path/to/sense2vec_vectors
+--senses NOUN,ORG,PRODUCT
+```
+
+### <kbd>recipe</kbd> `sense2vec.eval-ab`
+
+Perform an A/B evaluation of two pretrained sense2vec vector models by comparing
+the most similar entries they return for a random phrase. The UI shows two
+randomized options with the most similar entries of each model and highlights
+the phrases that differ. At the end of the annotation session the overall stats
+and preferred model are shown.
+
+```bash
+prodigy sense2vec.eval [dataset] [vectors_path_a] [vectors_path_b] [--senses]
+[--exclude-senses] [--n-freq] [--n-similar] [--batch-size] [--eval-whole]
+[--eval-only] [--show-mapping]
+```
+
+| Argument                  | Type       | Description                                                                                                   |
+| ------------------------- | ---------- | ------------------------------------------------------------------------------------------------------------- |
+| `dataset`                 | positional | Dataset to save annotations to.                                                                               |
+| `vectors_path_a`          | positional | Path to pretrained sense2vec vectors.                                                                         |
+| `vectors_path_b`          | positional | Path to pretrained sense2vec vectors.                                                                         |
+| `--senses`, `-s`          | option     | Comma-separated list of senses to limit the selection to. If not set, all senses in the vectors will be used. |
+| `--exclude-senses`, `-es` | option     | Comma-separated list of senses to exclude. See `prodigy_recipes.EVAL_EXCLUDE_SENSES` fro the defaults.        |
+| `--n-freq`, `-f`          | option     | Number of most frequent entries to limit to.                                                                  |
+| `--n-similar`, `-n`       | option     | Number of similar items to check. Defaults to `10`.                                                           |
+| `--batch-size`, `-b`      | option     | Batch size to use.                                                                                            |
+| `--eval-whole`, `-E`      | flag       | Evaluate the whole dataset instead of the current session.                                                    |
+| `--eval-only`, `-O`       | flag       | Don't annotate, only evaluate the current dataset.                                                            |
+| `--show-mapping`, `-S`    | flag       | Show which models are option 1 and option 2 in the UI (for debugging).                                        |
+
+```bash
+prodigy sense2vec.eval-ab vectors_eval_sim /path/to/sense2vec_vectors_a /path/to/sense2vec_vectors_b --senses NOUN,ORG,PRODUCT
+```
+
+![UI preview of sense2vec.eval-ab](https://user-images.githubusercontent.com/13643239/68088514-46d21780-fe60-11e9-9b29-fe313bb2154d.png)
 
 ## Pretrained vectors
 

--- a/sense2vec/prodigy_recipes.py
+++ b/sense2vec/prodigy_recipes.py
@@ -1,6 +1,7 @@
 import prodigy
 from prodigy.components.db import connect
 from prodigy.util import log, split_string, set_hashes, TASK_HASH_ATTR
+import murmurhash
 from sense2vec import Sense2Vec
 import srsly
 import spacy
@@ -250,6 +251,8 @@ def evaluate(
                 current_keys[sense].remove(key_b)
                 current_keys[sense].remove(key_c)
                 confidence = 1.0 - (min(sim_ab, sim_ac) / max(sim_ab, sim_ac))
+                # Get a more representative hash
+                task_hash = murmurhash.hash(" ".join([key_a] + sorted([key_b, key_c])))
                 task = {
                     "label": "Which one is more similar?",
                     "html": get_html(*s2v.split_key(key_a)),
@@ -267,6 +270,7 @@ def evaluate(
                         },
                     ],
                     "confidence": confidence,
+                    TASK_HASH_ATTR: task_hash,
                 }
                 if show_scores:
                     task["meta"] = {"confidence": f"{confidence:.4}"}

--- a/sense2vec/prodigy_recipes.py
+++ b/sense2vec/prodigy_recipes.py
@@ -4,83 +4,16 @@ from prodigy.util import log, split_string, set_hashes, TASK_HASH_ATTR
 from sense2vec import Sense2Vec
 import srsly
 import spacy
+import random
+from wasabi import Printer
+from collections import defaultdict
+import copy
 
 
 HTML_TEMPLATE = """
 <span style="font-size: {{theme.largeText}}px">{{word}}</span>
 <strong style="opacity: 0.75">{{sense}}</strong>
 """
-
-@prodigy.recipe(
-    "sense2vec.evaluate",
-    dataset=("Dataset to save annotations to", "positional", None, str),
-    model=("Name or path of sense2vec model", "positional", None, str),
-    tasks=("File with similarity triples to ask about. If none, questions will be generated.", "positional", None)
-)
-def evaluate(
-    dataset,
-    model,
-    tasks=None,
-):
-    """Evaluate a word vectors model by asking providing questions triples:
-    is word A more similar to word B, or to word C? If the human mostly agrees
-    with the model, the vectors model is good.
-    """
-    nlp = spacy.load(model)
-    
-    def get_stream(s2v):
-        keys = list(s2v.vectors.keys())
-        while True:
-            a, b, c = random.sample(keys, 3)
-            sim_ab = self.vectors.similarity(a, b)
-            sim_ac = self.vectors.similarity(a, c)
-            sim_bc = self.vectors.similarity(b, c)
-            wordA = s2v.strings[a]
-            wordB = s2v.strings[b]
-            wordC = s2v.strings[c]
-            confidence = 1. - (min(sim_ab, sim_ac) / max(sim_ab, sim_ac))
-
-            if sim_ab > sim_ac:
-                mapping = {"agree": accept, "disagree": reject}
-            else:
-                mapping = {"disagree": accept, "agree": reject}
-
-            task = {
-                "input": { "text": s2v.strings[a] },
-                "accept": { "text": s2v.strings[wordB] },
-                "reject": { "text": s2v.strings[wordC] },
-                "mapping": mapping,
-                "similarities": [
-                    {"pair": [wordA, wordB], "score": sim_ab},
-                    {"pair": [wordA, wordC], "score": sim_ac},
-                    {"pair": [wordB, wordC], "score": sim_bc}
-                ],
-                "confidence": confidence
-            }
-            task = set_hashes(task)
-            yield task
-
-    def update(answers):
-        """Updates accept_keys so that the stream can find new phrases."""
-        log(f"RECIPE: Updating with {len(answers)} answers")
-        loss = 0.
-        for eg in answers:
-            human = eg["answer"]
-            if eg["answer"] in ("accept", "reject"):
-                if eg["mapping"][eg["answer"]] == "agree":
-                    right += 1
-                else:
-                    wrong += 1
-                    loss += eg["confidence"]
-    return {
-        "view_id": "compare",
-        "dataset": dataset,
-        "stream": stream,
-        "update": update,
-        "config": {"batch_size": batch_size, "html_template": HTML_TEMPLATE},
-    }
-
-   
 
 
 @prodigy.recipe(
@@ -221,3 +154,104 @@ def to_patterns(
     if not dry:
         srsly.write_jsonl(output_file, patterns)
     return patterns
+
+
+@prodigy.recipe(
+    "sense2vec.evaluate",
+    dataset=("Dataset to save annotations to", "positional", None, str),
+    vectors_path=("Path to pretrained sense2vec vectors", "positional", None, str),
+    senses=("The senses to use (all if not set)", "option", "s", split_string),
+    n_freq=("Number of most frequent entries to limit to", "option", "f", int),
+    threshold=("Similarity threshold to consider examples", "option", "t", float),
+    eval_whole=("Evaluate whole dataset instead of session", "flag", "E", bool),
+)
+def evaluate(
+    dataset, vectors_path, senses=None, n_freq=100_000, threshold=0.7, eval_whole=False
+):
+    """Evaluate a word vectors model by asking providing questions triples:
+    is word A more similar to word B, or to word C? If the human mostly agrees
+    with the model, the vectors model is good.
+    """
+    random.seed(0)
+    log("RECIPE: Starting recipe sense2vec.evaluate", locals())
+    s2v = Sense2Vec().from_disk(vectors_path)
+    log("RECIPE: Loaded sense2vec vectors", vectors_path)
+
+    def get_stream():
+        html = "{} <strong style='opacity: 0.75; font-size: 14px; padding-left: 10px'>{}</strong>"
+        # Limit to most frequent entries
+        keys = [key for key, _ in s2v.frequencies[:n_freq]]
+        keys_by_sense = defaultdict(set)
+        for key in keys:
+            sense = s2v.split_key(key)[1]
+            if senses is None or sense in senses:
+                keys_by_sense[sense].add(key)
+        keys_by_sense = {s: keys for s, keys in keys_by_sense.items() if len(keys) >= 3}
+        all_senses = list(keys_by_sense.keys())
+        total_keys = sum(len(keys) for keys in keys_by_sense.values())
+        log(f"RECIPE: Using {total_keys} entries for {len(all_senses)} senses")
+        while True:
+            current_keys = copy.deepcopy(keys_by_sense)
+            while any(len(values) >= 3 for values in current_keys.values()):
+                sense = random.choice(all_senses)
+                key_a, key_b, key_c = random.sample(current_keys[sense], 3)
+                if len(set([key_a.lower(), key_b.lower(), key_c.lower()])) != 3:
+                    continue
+                sim_ab = s2v.similarity(key_a, key_b)
+                sim_ac = s2v.similarity(key_a, key_c)
+                if sim_ab < threshold or sim_ac < threshold:
+                    continue
+                current_keys[sense].remove(key_a)
+                current_keys[sense].remove(key_b)
+                current_keys[sense].remove(key_c)
+                confidence = 1.0 - (min(sim_ab, sim_ac) / max(sim_ab, sim_ac))
+                task = {
+                    "label": "Which one is more similar?",
+                    "html": html.format(*s2v.split_key(key_a)),
+                    "key": key_a,
+                    "options": [
+                        {
+                            "id": key_b,
+                            "html": html.format(*s2v.split_key(key_b)),
+                            "score": sim_ab,
+                        },
+                        {
+                            "id": key_c,
+                            "html": html.format(*s2v.split_key(key_c)),
+                            "score": sim_ac,
+                        },
+                    ],
+                    "confidence": confidence,
+                }
+                yield task
+
+    def on_exit(ctrl):
+        """Output summary about user agreement with the model."""
+        msg = Printer()
+        set_id = dataset if eval_whole else ctrl.session_id
+        data = ctrl.db.get_dataset(set_id)
+        data = [eg for eg in data if eg["answer"] == "accept" and eg.get("accept")]
+        if not data:
+            msg.warn("No annotations collected", exits=1)
+        agree_count = 0
+        for eg in data:
+            choice = eg["accept"][0]
+            score_choice = [o["score"] for o in eg["options"] if o["id"] == choice][0]
+            score_other = [o["score"] for o in eg["options"] if o["id"] != choice][0]
+            if score_choice > score_other:
+                agree_count += 1
+        pc = agree_count / len(data)
+        text = f"You agreed {agree_count} / {len(data)} times ({pc:.0%})"
+        msg.info(f"Evaluating data from '{set_id}'")
+        if pc > 0.5:
+            msg.good(text)
+        else:
+            msg.fail(text)
+
+    return {
+        "view_id": "choice",
+        "dataset": dataset,
+        "stream": get_stream(),
+        "on_exit": on_exit,
+        "config": {"choice_style": "single", "choice_auto_accept": True},
+    }

--- a/sense2vec/prodigy_recipes.py
+++ b/sense2vec/prodigy_recipes.py
@@ -193,12 +193,15 @@ def evaluate(
         if not data:
             msg.warn("No annotations collected", exits=1)
         agree_count = 0
+        disagree_high_conf = 0
         for eg in data:
             choice = eg["accept"][0]
             score_choice = [o["score"] for o in eg["options"] if o["id"] == choice][0]
             score_other = [o["score"] for o in eg["options"] if o["id"] != choice][0]
             if score_choice > score_other:
                 agree_count += 1
+            elif eg["confidence"] > 0.8:
+                disagree_high_conf += 1
         pc = agree_count / len(data)
         text = f"You agreed {agree_count} / {len(data)} times ({pc:.0%})"
         msg.info(f"Evaluating data from '{set_id}'")
@@ -206,6 +209,7 @@ def evaluate(
             msg.good(text)
         else:
             msg.fail(text)
+        msg.text(f"You disagreed on {disagree_high_conf} high confidence scores")
 
     if eval_only:
         eval_dataset(dataset)

--- a/sense2vec/prodigy_recipes.py
+++ b/sense2vec/prodigy_recipes.py
@@ -254,7 +254,7 @@ def evaluate(
                             options.append((key, score))
                     if len(options) < 2:
                         continue
-                    key_b, sim_ab = options[round(len(options) / 2)]
+                    key_b, sim_ab = options[len(options) // 2]
                     key_c, sim_ac = options[-1]
                 else:
                     key_a, key_b, key_c = random.sample(current_keys[sense], 3)

--- a/sense2vec/prodigy_recipes.py
+++ b/sense2vec/prodigy_recipes.py
@@ -263,14 +263,14 @@ def evaluate(
                 sense = random.choice(all_senses)
                 if strategy == "most_similar":
                     key_a = random.choice(list(current_keys[sense]))
-                    most_similar = s2v.most_similar(key_a, n=100)
+                    most_similar = s2v.most_similar(key_a, n=200)
                     options = []
                     for key, score in most_similar:
                         if key in current_keys[sense]:
                             options.append((key, score))
                     if len(options) < 2:
                         continue
-                    key_b, sim_ab = options[len(options) // 2]
+                    key_b, sim_ab = options[len(options) // 4]
                     key_c, sim_ac = options[-1]
                 else:
                     key_a, key_b, key_c = random.sample(current_keys[sense], 3)

--- a/sense2vec/prodigy_recipes.py
+++ b/sense2vec/prodigy_recipes.py
@@ -1,14 +1,22 @@
 import prodigy
 from prodigy.components.db import connect
-from prodigy.util import log, split_string, set_hashes, TASK_HASH_ATTR
+from prodigy.util import log, split_string, set_hashes, TASK_HASH_ATTR, INPUT_HASH_ATTR
 import murmurhash
 from sense2vec import Sense2Vec
 import srsly
 import spacy
 import random
 from wasabi import Printer
-from collections import defaultdict
+from collections import defaultdict, Counter
 import copy
+import catalogue
+
+
+# fmt: off
+eval_strategies = catalogue.create("prodigy", "sense2vec.eval")
+EVAL_EXCLUDE_SENSES = ("SYM", "MONEY", "ORDINAL", "CARDINAL", "DATE", "TIME",
+                       "PERCENT", "QUANTITY", "NUM", "X", "PUNCT")
+# fmt: on
 
 
 @prodigy.recipe(
@@ -127,10 +135,11 @@ def to_patterns(
     dataset, spacy_model, label, output_file="-", case_sensitive=False, dry=False
 ):
     """
-    Convert a list of seed phrases to a list of token-based match patterns that
-    can be used with spaCy's EntityRuler or recipes like ner.match. If no output
-    file is specified, the patterns are written to stdout. The examples are
-    tokenized so that multi-token terms are represented correctly, e.g.:
+    Convert a dataset of phrases collected with sense2vec.teach to token-based
+    match patterns that can be used with spaCy's EntityRuler or recipes like
+    ner.match. If no output file is specified, the patterns are written to
+    stdout. The examples are tokenized so that multi-token terms are represented
+    correctly, e.g.:
     {"label": "SHOE_BRAND", "pattern": [{"LOWER": "new"}, {"LOWER": "balance"}]}
     """
     log("RECIPE: Starting recipe sense2vec.to-patterns", locals())
@@ -153,7 +162,7 @@ def to_patterns(
 
 
 @prodigy.recipe(
-    "sense2vec.evaluate",
+    "sense2vec.eval",
     dataset=("Dataset to save annotations to", "positional", None, str),
     vectors_path=("Path to pretrained sense2vec vectors", "positional", None, str),
     strategy=("Example selection strategy", "option", "st", str,),
@@ -171,43 +180,105 @@ def evaluate(
     vectors_path,
     strategy="most_similar",
     senses=None,
-    exclude_senses=(
-        "SYM",
-        "MONEY",
-        "ORDINAL",
-        "CARDINAL",
-        "DATE",
-        "TIME",
-        "PERCENT",
-        "QUANTITY",
-        "NUM",
-        "X",
-        "PUNCT",
-    ),
+    exclude_senses=EVAL_EXCLUDE_SENSES,
     n_freq=100_000,
     threshold=0.7,
-    batch_size=5,
+    batch_size=10,
     eval_whole=False,
     eval_only=False,
     show_scores=False,
 ):
-    """Evaluate a word vectors model by asking providing questions triples:
-    is word A more similar to word B, or to word C? If the human mostly agrees
-    with the model, the vectors model is good.
+    """
+    Evaluate a sense2vec model by asking about phrase triples: is word A more
+    similar to word B, or to word C? If the human mostly agrees with the model,
+    the vectors model is good.
     """
     msg = Printer()
     random.seed(0)
-    log("RECIPE: Starting recipe sense2vec.evaluate", locals())
-    strategies = ["random", "most_similar"]
-    if strategy not in strategies:
-        msg.fail(f"Invalid strategy '{strategy}'. Expected: {strategies}", exits=1)
+    log("RECIPE: Starting recipe sense2vec.eval", locals())
+    strategies = eval_strategies.get_all()
+    if strategy not in strategies.keys():
+        err = f"Invalid strategy '{strategy}'. Expected: {list(strategies.keys())}"
+        msg.fail(err, exits=1)
     s2v = Sense2Vec().from_disk(vectors_path)
     log("RECIPE: Loaded sense2vec vectors", vectors_path)
 
+    def get_html(key, score=None, large=False):
+        word, sense = s2v.split_key(key)
+        html_word = f"<span style='font-size: {30 if large else 20}px'>{word}</span>"
+        html_sense = f"<strong style='opacity: 0.75; font-size: 14px; padding-left: 10px'>{sense}</strong>"
+        html = f"{html_word} {html_sense}"
+        if show_scores and score is not None:
+            html += f" <span style='opacity: 0.75; font-size: 12px; padding-left: 10px'>{score:.4}</span>"
+        return html
+
+    def get_stream():
+        strategy_func = eval_strategies.get(strategy)
+        log(f"RECIPE: Using strategy {strategy}")
+        # Limit to most frequent entries
+        keys = [key for key, _ in s2v.frequencies[:n_freq]]
+        keys_by_sense = defaultdict(set)
+        for key in keys:
+            try:
+                sense = s2v.split_key(key)[1]
+            except ValueError:
+                continue
+            if (senses is None or sense in senses) and sense not in exclude_senses:
+                keys_by_sense[sense].add(key)
+        keys_by_sense = {s: keys for s, keys in keys_by_sense.items() if len(keys) >= 3}
+        all_senses = list(keys_by_sense.keys())
+        total_keys = sum(len(keys) for keys in keys_by_sense.values())
+        log(f"RECIPE: Using {total_keys} entries for {len(all_senses)} senses")
+        n_passes = 1
+        while True:
+            log(f"RECIPE: Iterating over the data ({n_passes})")
+            current_keys = copy.deepcopy(keys_by_sense)
+            while any(len(values) >= 3 for values in current_keys.values()):
+                sense = random.choice(all_senses)
+                all_keys = list(current_keys[sense])
+                key_a, key_b, key_c, sim_ab, sim_ac = strategy_func(s2v, all_keys)
+                if len(set([key_a.lower(), key_b.lower(), key_c.lower()])) != 3:
+                    continue
+                if sim_ab < threshold or sim_ac < threshold:
+                    continue
+                for key in (key_a, key_b, key_c):
+                    current_keys[sense].remove(key)
+                confidence = 1.0 - (min(sim_ab, sim_ac) / max(sim_ab, sim_ac))
+                input_hash = murmurhash.hash(key_a)
+                task_hash = murmurhash.hash(" ".join([key_a] + sorted([key_b, key_c])))
+                task = {
+                    "label": "Which one is more similar?",
+                    "html": get_html(key_a, large=True),
+                    "text": f"{key_a}: {key_b}, {key_c}",
+                    "key": key_a,
+                    "options": [
+                        {
+                            "id": key_b,
+                            "html": get_html(key_b, sim_ab),
+                            "score": sim_ab,
+                        },
+                        {
+                            "id": key_c,
+                            "html": get_html(key_c, sim_ac),
+                            "score": sim_ac,
+                        },
+                    ],
+                    "confidence": confidence,
+                    TASK_HASH_ATTR: task_hash,
+                    INPUT_HASH_ATTR: input_hash,
+                }
+                if show_scores:
+                    task["meta"] = {
+                        "confidence": f"{confidence:.4}",
+                        "strategy": strategy,
+                    }
+                yield task
+            n_passes += 1
+
     def eval_dataset(set_id):
         """Output summary about user agreement with the model."""
-        db = connect()
-        data = db.get_dataset(set_id)
+        DB = connect()
+        data = DB.get_dataset(set_id)
         accepted = [eg for eg in data if eg["answer"] == "accept" and eg.get("accept")]
         rejected = [eg for eg in data if eg["answer"] == "reject"]
         if not accepted and not rejected:
@@ -233,11 +304,107 @@ def evaluate(
         msg.text(f"You disagreed on {disagree_high_conf} high confidence scores")
         msg.text(f"You rejected {len(rejected)} suggestions as not similar")
 
+    def on_exit(ctrl):
+        set_id = dataset if eval_whole else ctrl.session_id
+        eval_dataset(set_id)
+
     if eval_only:
         eval_dataset(dataset)
         return None
 
-    def get_html(word, sense, score=None, large=False):
+    return {
+        "view_id": "choice",
+        "dataset": dataset,
+        "stream": get_stream(),
+        "on_exit": on_exit,
+        "config": {
+            "batch_size": batch_size,
+            "choice_style": "single",
+            "choice_auto_accept": True,
+        },
+    }
+
+
+@eval_strategies.register("random")
+def eval_strategy_random(s2v, keys):
+    key_a, key_b, key_c = random.sample(keys, 3)
+    sim_ab = s2v.similarity(key_a, key_b)
+    sim_ac = s2v.similarity(key_a, key_c)
+    return key_a, key_b, key_c, sim_ab, sim_ac
+
+
+@eval_strategies.register("most_similar")
+def eval_strategy_most_similar(s2v, keys):
+    key_a = random.choice(keys)
+    most_similar = s2v.most_similar(key_a, n=min(2000, len(s2v)))
+    options = [(key, score) for key, score in most_similar if key in keys]
+    if len(options) < 2:
+        return eval_strategy_most_similar(s2v, keys)
+    key_b, sim_ab = options[len(options) // 2]
+    key_c, sim_ac = options[-1]
+    return key_a, key_b, key_c, sim_ab, sim_ac
+
+
+@eval_strategies.register("most_least_similar")
+def eval_strategy_most_least_similar(s2v, keys):
+    n_similar = 100
+    key_a = random.choice(keys)
+    most_similar_a = s2v.most_similar(key_a, n=n_similar)
+    options_a = [(key, score) for key, score in most_similar_a if key in keys]
+    if len(options_a) < 1:
+        return eval_strategy_most_least_similar(s2v, keys)
+    key_b, sim_ab = options_a[-1]
+    most_similar_b = s2v.most_similar(key_b, n=n_similar)
+    options_b = [(key, score) for key, score in most_similar_b if key in keys]
+    if len(options_b) < 1:
+        return eval_strategy_most_least_similar(s2v, keys)
+    key_c, sim_ac = options_b[-1]
+    return key_a, key_b, key_c, sim_ab, sim_ac
+
+
+@prodigy.recipe(
+    "sense2vec.eval-most-similar",
+    dataset=("Dataset to save annotations to", "positional", None, str),
+    vectors_path=("Path to pretrained sense2vec vectors", "positional", None, str),
+    senses=("The senses to use (all if not set)", "option", "s", split_string),
+    exclude_senses=("The senses to exclude", "option", "es", split_string),
+    n_freq=("Number of most frequent entries to limit to", "option", "f", int),
+    n_similar=("Number of similar items to check", "option", "n", int),
+    batch_size=("The batch size to use", "option", "b", int),
+    eval_whole=("Evaluate whole dataset instead of session", "flag", "E", bool),
+    eval_only=("Don't annotate, only evaluate current set", "flag", "O", bool),
+    show_scores=("Show all scores for debugging", "flag", "S", bool),
+)
+def eval_most_similar(
+    dataset,
+    vectors_path,
+    senses=None,
+    exclude_senses=EVAL_EXCLUDE_SENSES,
+    n_freq=100_000,
+    n_similar=10,
+    batch_size=5,
+    eval_whole=False,
+    eval_only=False,
+    show_scores=False,
+):
+    """
+    Evaluate a vectors model by looking at the most similar entries it returns
+    for a random phrase and unselecting the mistakes.
+    """
+    log("RECIPE: Starting recipe sense2vec.eval-most-similar", locals())
+    msg = Printer()
+    random.seed(0)
+    s2v = Sense2Vec().from_disk(vectors_path)
+    log("RECIPE: Loaded sense2vec vectors", vectors_path)
+    seen = set()
+    DB = connect()
+    if dataset in DB:
+        examples = DB.get_dataset(dataset)
+        seen.update([eg["text"] for eg in examples if eg["answer"] == "accept"])
+        log(f"RECIPE: Skipping {len(seen)} terms already in dataset")
+
+    def get_html(key, score=None, large=False):
+        word, sense = s2v.split_key(key)
         html_word = f"<span style='font-size: {30 if large else 20}px'>{word}</span>"
         html_sense = f"<strong style='opacity: 0.75; font-size: 14px; padding-left: 10px'>{sense}</strong>"
         html = f"{html_word} {html_sense}"
@@ -246,75 +413,203 @@ def evaluate(
         return html
 
     def get_stream():
-        # Limit to most frequent entries
-        keys = [key for key, _ in s2v.frequencies[:n_freq]]
-        keys_by_sense = defaultdict(set)
-        for key in keys:
-            sense = s2v.split_key(key)[1]
-            if (senses is None or sense in senses) and sense not in exclude_senses:
-                keys_by_sense[sense].add(key)
-        keys_by_sense = {s: keys for s, keys in keys_by_sense.items() if len(keys) >= 3}
-        all_senses = list(keys_by_sense.keys())
-        total_keys = sum(len(keys) for keys in keys_by_sense.values())
-        log(f"RECIPE: Using {total_keys} entries for {len(all_senses)} senses")
-        while True:
-            current_keys = copy.deepcopy(keys_by_sense)
-            while any(len(values) >= 3 for values in current_keys.values()):
-                sense = random.choice(all_senses)
-                if strategy == "most_similar":
-                    key_a = random.choice(list(current_keys[sense]))
-                    most_similar = s2v.most_similar(key_a, n=200)
-                    options = []
-                    for key, score in most_similar:
-                        if key in current_keys[sense]:
-                            options.append((key, score))
-                    if len(options) < 2:
-                        continue
-                    key_b, sim_ab = options[len(options) // 4]
-                    key_c, sim_ac = options[-1]
-                else:
-                    key_a, key_b, key_c = random.sample(current_keys[sense], 3)
-                    sim_ab = s2v.similarity(key_a, key_b)
-                    sim_ac = s2v.similarity(key_a, key_c)
-                if len(set([key_a.lower(), key_b.lower(), key_c.lower()])) != 3:
-                    continue
-                if sim_ab < threshold or sim_ac < threshold:
-                    continue
-                current_keys[sense].remove(key_a)
-                current_keys[sense].remove(key_b)
-                current_keys[sense].remove(key_c)
-                confidence = 1.0 - (min(sim_ab, sim_ac) / max(sim_ab, sim_ac))
-                # Get a more representative hash
-                task_hash = murmurhash.hash(" ".join([key_a] + sorted([key_b, key_c])))
-                task = {
-                    "label": "Which one is more similar?",
-                    "html": get_html(*s2v.split_key(key_a), large=True),
-                    "key": key_a,
-                    "options": [
-                        {
-                            "id": key_b,
-                            "html": get_html(*s2v.split_key(key_b), sim_ab),
-                            "score": sim_ab,
-                        },
-                        {
-                            "id": key_c,
-                            "html": get_html(*s2v.split_key(key_c), sim_ac),
-                            "score": sim_ac,
-                        },
-                    ],
-                    "confidence": confidence,
-                    TASK_HASH_ATTR: task_hash,
-                }
-                if show_scores:
-                    task["meta"] = {
-                        "confidence": f"{confidence:.4}",
-                        "strategy": strategy,
-                    }
-                yield task
+        keys = [key for key, _ in s2v.frequencies[:n_freq] if key not in seen]
+        while len(keys):
+            key = random.choice(keys)
+            keys.remove(key)
+            word, sense = s2v.split_key(key)
+            if sense in exclude_senses or (senses is not None and sense not in senses):
+                continue
+            most_similar = s2v.most_similar(key, n=n_similar)
+            options = [{"id": k, "html": get_html(k, s)} for k, s in most_similar]
+            task_hash = murmurhash.hash(key)
+            task = {
+                "html": get_html(key, large=True),
+                "text": key,
+                "options": options,
+                "accept": [key for key, _ in most_similar],  # pre-select all
+                TASK_HASH_ATTR: task_hash,
+                INPUT_HASH_ATTR: task_hash,
+            }
+            yield task
+
+    def eval_dataset(set_id):
+        DB = connect()
+        data = DB.get_dataset(set_id)
+        accepted = [eg for eg in data if eg["answer"] == "accept" and eg.get("accept")]
+        rejected = [eg for eg in data if eg["answer"] == "reject"]
+        ignored = [eg for eg in data if eg["answer"] == "ignore"]
+        if not accepted and not rejected:
+            msg.warn("No annotations collected", exits=1)
+        total_count = 0
+        agree_count = 0
+        for eg in accepted:
+            total_count += len(eg.get("options", []))
+            agree_count += len(eg.get("accept", []))
+        msg.info(f"Evaluating data from '{set_id}'")
+        msg.text(f"You rejected {len(rejected)} and ignored {len(ignored)} pair(s)")
+        pc = agree_count / total_count
+        text = f"You agreed {agree_count} / {total_count} times ({pc:.0%})"
+        if pc > 0.5:
+            msg.good(text)
+        else:
+            msg.fail(text)
 
     def on_exit(ctrl):
         set_id = dataset if eval_whole else ctrl.session_id
         eval_dataset(set_id)
+
+    if eval_only:
+        eval_dataset(dataset)
+        return None
+
+    return {
+        "view_id": "choice",
+        "dataset": dataset,
+        "stream": get_stream(),
+        "on_exit": on_exit,
+        "config": {"choice_style": "multiple", "batch_size": batch_size},
+    }
+
+
+@prodigy.recipe(
+    "sense2vec.eval-ab",
+    dataset=("Dataset to save annotations to", "positional", None, str),
+    vectors_path_a=("Path to pretrained sense2vec vectors", "positional", None, str),
+    vectors_path_b=("Path to pretrained sense2vec vectors", "positional", None, str),
+    senses=("The senses to use (all if not set)", "option", "s", split_string),
+    exclude_senses=("The senses to exclude", "option", "es", split_string),
+    n_freq=("Number of most frequent entries to limit to", "option", "f", int),
+    batch_size=("The batch size to use", "option", "b", int),
+    eval_whole=("Evaluate whole dataset instead of session", "flag", "E", bool),
+    eval_only=("Don't annotate, only evaluate current set", "flag", "O", bool),
+    show_mapping=("Show A/B mapping for debugging", "flag", "S", bool),
+)
+def eval_ab(
+    dataset,
+    vectors_path_a,
+    vectors_path_b,
+    senses=None,
+    exclude_senses=EVAL_EXCLUDE_SENSES,
+    n_freq=100_000,
+    n_similar=10,
+    batch_size=5,
+    eval_whole=False,
+    eval_only=False,
+    show_mapping=False,
+):
+    """
+    Perform an A/B evaluation of two pretrained sense2vec vector models by
+    comparing the most similar entries they return for a random phrase. The
+    UI shows two randomized options with the most similar entries of each model
+    and highlights the phrases that differ. At the end of the annotation
+    session the overall stats and preferred model are shown.
+    """
+    log("RECIPE: Starting recipe sense2vec.eval-ab", locals())
+    msg = Printer()
+    random.seed(0)
+    s2v_a = Sense2Vec().from_disk(vectors_path_a)
+    s2v_b = Sense2Vec().from_disk(vectors_path_b)
+    mapping = {"A": vectors_path_a, "B": vectors_path_b}
+    log("RECIPE: Loaded sense2vec vectors", (vectors_path_a, vectors_path_b))
+    seen = set()
+    DB = connect()
+    if dataset in DB:
+        examples = DB.get_dataset(dataset)
+        seen.update([eg["text"] for eg in examples if eg["answer"] == "accept"])
+        log(f"RECIPE: Skipping {len(seen)} terms already in dataset")
+
+    def get_term_html(key):
+        word, sense = s2v_a.split_key(key)
+        return (
+            f"<span style='font-size: 30px'>{word}</span> "
+            f"<strong style='opacity: 0.75; font-size: 14px; padding-left: "
+            f"10px'>{sense}</strong>"
+        )
+
+    def get_option_html(most_similar, overlap):
+        html = []
+        for key in most_similar:
+            font_weight = "normal" if key in overlap else "bold"
+            border_color = "#f6f6f6" if key in overlap else "#ccc"
+            word, sense = s2v_a.split_key(key)
+            html.append(
+                f"<span style='display: inline-block; background: #f6f6f6; "
+                f"font-weight: {font_weight}; border: 1px solid {border_color}; "
+                f"padding: 0 8px; margin: 0 5px 5px 0; border-radius: 5px; "
+                f"white-space: nowrap'>{word} <span style='font-weight: bold; "
+                f"text-transform: uppercase; font-size: 10px; margin-left: "
+                f"5px'>{sense}</span></span>"
+            )
+        html = " ".join(html) if html else "<em>No results</em>"
+        return (
+            f"<div style='font-size: 16px; line-height: 1.75; padding: 5px "
+            f"12px 5px 0'>{html}</div>"
+        )
+
+    def get_stream():
+        keys_a = [key for key, _ in s2v_a.frequencies[:n_freq] if key not in seen]
+        keys_b = [key for key, _ in s2v_b.frequencies[:n_freq] if key not in seen]
+        while len(keys_a):
+            key = random.choice(keys_a)
+            keys_a.remove(key)
+            word, sense = s2v_a.split_key(key)
+            if sense in exclude_senses or (senses is not None and sense not in senses):
+                continue
+            if key not in keys_b:
+                continue
+            similar_a = set(s2v_a.most_similar(key, n=n_similar))
+            similar_b = set(s2v_b.most_similar(key, n=n_similar))
+            overlap = similar_a.intersection(similar_b)
+            options = [
+                {"id": "A", "html": get_option_html(similar_a, overlap)},
+                {"id": "B", "html": get_option_html(similar_b, overlap)},
+            ]
+            random.shuffle(options)
+            task_hash = murmurhash.hash(key)
+            task = {
+                "html": get_term_html(key),
+                "text": key,
+                "options": options,
+                TASK_HASH_ATTR: task_hash,
+                INPUT_HASH_ATTR: task_hash,
+            }
+            if show_mapping:
+                task["meta"] = {
+                    i + 1: f"{opt['id']} ({mapping[opt['id']]})"
+                    for i, opt in enumerate(options)
+                }
+            yield task
+
+    def eval_dataset(set_id):
+        DB = connect()
+        data = DB.get_dataset(set_id)
+        accepted = [eg for eg in data if eg["answer"] == "accept" and eg.get("accept")]
+        rejected = [eg for eg in data if eg["answer"] == "reject"]
+        ignored = [eg for eg in data if eg["answer"] == "ignore"]
+        if not accepted and not rejected:
+            msg.warn("No annotations collected", exits=1)
+        counts = Counter()
+        for eg in accepted:
+            for model_id in eg["accept"]:
+                counts[model_id] += 1
+        preference = max(counts)
+        ratio = f"{counts[preference]} / {sum(counts.values()) - counts[preference]}"
+        msg.info(f"Evaluating data from {set_id}")
+        msg.text(f"You rejected {len(rejected)} and ignored {len(ignored)} pair(s)")
+        if counts["A"] == counts["B"]:
+            msg.warn(f"No preference ({ratio})")
+        else:
+            msg.good(f"You preferred vectors {preference} ({ratio})")
+            msg.text(mapping[preference])
+
+    def on_exit(ctrl):
+        set_id = dataset if eval_whole else ctrl.session_id
+        eval_dataset(set_id)
+
+    if eval_only:
+        eval_dataset(dataset)
+        return None
 
     return {
         "view_id": "choice",

--- a/setup.cfg
+++ b/setup.cfg
@@ -38,8 +38,10 @@ spacy_factories =
     sense2vec = sense2vec:Sense2VecComponent.from_nlp
 prodigy_recipes =
     sense2vec.teach = sense2vec:prodigy_recipes.teach
-    sens2vec.to_patterns = sense2vec:prodigy_recipes.to_patterns
-    sens2vec.evaluate = sense2vec:prodigy_recipes.evaluate
+    sens2vec.to-patterns = sense2vec:prodigy_recipes.to_patterns
+    sense2vec.eval = sense2vec:prodigy_recipes.evaluate
+    sense2vec.eval-most-similar = sense2vec:prodigy_recipes.eval_most_similar
+    sense2vec.eval-ab = sense2vec:prodigy_recipes.eval_ab
 
 [bdist_wheel]
 universal = true

--- a/setup.cfg
+++ b/setup.cfg
@@ -38,6 +38,7 @@ spacy_factories =
 prodigy_recipes =
     sense2vec.teach = sense2vec:prodigy_recipes.teach
     sens2vec.to_patterns = sense2vec:prodigy_recipes.to_patterns
+    sens2vec.evaluate = sense2vec:prodigy_recipes.evaluate
 
 [bdist_wheel]
 universal = true


### PR DESCRIPTION
Allows streaming in vector triples to annotate which of two options is more similar to the third. Displays stats at the end, including how often annotator agreed with model.

Examples are selected from the most frequent entries and by sense (random sense first, then random triple if 3 or more keys are available for that sense). Examples are only considered if their similarity scores exceed a certain threshold.

### Usage example

```bash
prodigy sense2vec.evaluate s2v_eval tmp/sense2vec-vectors --senses VERB,NOUN,ORG,PRODUCT --threshold 0.5
```

### UI example 

<img width="788" alt="Screenshot 2019-11-01 at 00 35 28" src="https://user-images.githubusercontent.com/13643239/67994212-668cf400-fc44-11e9-8fe2-bf264ae32b0a.png">
