### PR TITLE
Add options to prune vocab during export

### DIFF
--- a/scripts/05_export.py
+++ b/scripts/05_export.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
+from collections import OrderedDict, defaultdict
 from sense2vec import Sense2Vec
-from sense2vec.util import split_key
+from sense2vec.util import split_key, cosine_similarity
 from pathlib import Path
 import plac
 from wasabi import msg
@@ -22,12 +23,75 @@ def _get_shape(file_):
     return shape, file_
 
 
+def read_vocab(vocab_file):
+    freqs = OrderedDict()
+    for line in vocab_file:
+        item = line.rstrip()
+        if item.endswith(" word"):  # for fastText vocabs
+            item = item[:-5]
+        try:
+            key, freq = item.rsplit(" ", 1)
+        except ValueError:
+            continue
+        freqs[key] = int(freq)
+    return freqs
+ 
+
+def get_minority_keys(freqs, min_ratio):
+    """Remove keys that are too infrequent relative to a main sense."""
+    by_word = defaultdict(list)
+    for key, freq in freqs.items():
+        try:
+            term, sense = split_key(key)
+        except ValueError:
+            continue
+        if freq:
+            by_word[term.lower()].append((freq, key))
+    discarded = []
+    for values in by_word.values():
+        if len(values) >= 2:
+            values.sort(reverse=True)
+            freq1, key1 = values[0]
+            for freq2, key2 in values[1:]:
+                ratio = freq2 / freq1
+                if ratio < min_ratio:
+                    discarded.append(key2)
+    return discarded
+
+
+def get_redundant_keys(vocab, vectors, min_distance):
+    if min_distance <= 0.0:
+        return []
+    by_word = defaultdict(list)
+    for key, freq in vocab.items():
+        try:
+            term, sense = split_key(key)
+        except ValueError:
+            continue
+        term = term.split("_")[-1]
+        by_word[term.lower()].append((freq, key))
+    too_similar = []
+    for values in by_word.values():
+        if len(values) >= 2:
+            values.sort(reverse=True)
+            freq1, key1 = values[0]
+            vector1 = vectors[key1]
+            for freq2, key2 in values[1:]:
+                vector2 = vectors[key2]
+                sim = cosine_similarity(vector1, vector2)
+                if sim >= (1-min_distance):
+                    too_similar.append(key2)
+    return too_similar
+
+
 @plac.annotations(
     in_file=("Vectors file (text-based)", "positional", None, str),
     vocab_file=("Vocabulary file", "positional", None, str),
     out_dir=("Path to output directory", "positional", None, str),
+    min_freq_ratio=("Frequency ratio threshold for discarding minority senses or casings.", "option", "r", float),
+    min_distance=("Similarity threshold for discarding redundant keys.", "option", "s", float)
 )
-def main(in_file, vocab_file, out_dir):
+def main(in_file, vocab_file, out_dir, min_freq_ratio=0.0, min_distance=0.0):
     """
     Step 5: Export a sense2vec component
 
@@ -50,8 +114,8 @@ def main(in_file, vocab_file, out_dir):
         (n_vectors, vector_size), f = _get_shape(f)
         vectors_data = f.readlines()
     with vocab_path.open("r", encoding="utf8") as f:
-        vocab_data = f.readlines()
-    data = []
+        vocab = read_vocab(f)
+    vectors = {}
     all_senses = set()
     for item in vectors_data:
         item = item.rstrip().rsplit(" ", vector_size)
@@ -64,21 +128,18 @@ def main(in_file, vocab_file, out_dir):
         if len(vec) != vector_size:
             msg.fail(f"Wrong vector size: {len(vec)} (expected {vector_size})", exits=1)
         all_senses.add(sense)
-        data.append((key, numpy.asarray(vec, dtype=numpy.float32)))
-    s2v = Sense2Vec(shape=(len(data), vector_size), senses=all_senses)
-    for key, vector in data:
-        s2v.add(key, vector)
-    for item in vocab_data:
-        item = item.rstrip()
-        if item.endswith(" word"):  # for fastText vocabs
-            item = item[:-5]
-        try:
-            key, freq = item.rsplit(" ", 1)
-        except ValueError:
-            continue
-        s2v.set_freq(key, int(freq))
+        vectors[key] = numpy.asarray(vec, dtype=numpy.float32)
+    discarded = set()
+    discarded.update(get_minority_keys(vocab, min_freq_ratio))
+    discarded.update(get_redundant_keys(vocab, vectors, min_distance))
+    n_vectors = len(vectors) - len(discarded)
+    s2v = Sense2Vec(shape=(n_vectors, vector_size), senses=all_senses)
+    for key, vector in vectors.items():
+        if key not in discarded:
+            s2v.add(key, vector)
+            s2v.set_freq(key, vocab[key])
     msg.good("Created the sense2vec model")
-    msg.info(f"{len(data)} vectors, {len(all_senses)} total senses")
+    msg.info(f"{n_vectors} vectors, {len(all_senses)} total senses")
     s2v.to_disk(output_path)
     msg.good("Saved model to directory", out_dir)
 

--- a/scripts/05_export.py
+++ b/scripts/05_export.py
@@ -35,7 +35,7 @@ def read_vocab(vocab_file):
             continue
         freqs[key] = int(freq)
     return freqs
- 
+
 
 def get_minority_keys(freqs, min_ratio):
     """Remove keys that are too infrequent relative to a main sense."""
@@ -79,7 +79,7 @@ def get_redundant_keys(vocab, vectors, min_distance):
             for freq2, key2 in values[1:]:
                 vector2 = vectors[key2]
                 sim = cosine_similarity(vector1, vector2)
-                if sim >= (1-min_distance):
+                if sim >= (1 - min_distance):
                     too_similar.append(key2)
     return too_similar
 
@@ -88,8 +88,18 @@ def get_redundant_keys(vocab, vectors, min_distance):
     in_file=("Vectors file (text-based)", "positional", None, str),
     vocab_file=("Vocabulary file", "positional", None, str),
     out_dir=("Path to output directory", "positional", None, str),
-    min_freq_ratio=("Frequency ratio threshold for discarding minority senses or casings.", "option", "r", float),
-    min_distance=("Similarity threshold for discarding redundant keys.", "option", "s", float)
+    min_freq_ratio=(
+        "Frequency ratio threshold for discarding minority senses or casings.",
+        "option",
+        "r",
+        float,
+    ),
+    min_distance=(
+        "Similarity threshold for discarding redundant keys.",
+        "option",
+        "s",
+        float,
+    ),
 )
 def main(in_file, vocab_file, out_dir, min_freq_ratio=0.0, min_distance=0.0):
     """

--- a/scripts/06_precompute_cache.py
+++ b/scripts/06_precompute_cache.py
@@ -32,9 +32,9 @@ def main(
     else:
         import cupy as xp
         import cupy.cuda.device
-
-        cupy.take_along_axis = take_along_axis
+        xp.take_along_axis = take_along_axis
         device = cupy.cuda.device.Device(gpu_id)
+        cupy.cuda.get_cublas_handle()
         device.use()
     vectors_dir = Path(vectors)
     vectors_file = vectors_dir / "vectors"

--- a/scripts/06_precompute_cache.py
+++ b/scripts/06_precompute_cache.py
@@ -11,7 +11,7 @@ from pathlib import Path
     gpu_id=("GPU device (-1 for CPU)", "option", "g", int),
     n_neighbors=("Number of neighbors to cache", "option", "n", int),
     batch_size=("Batch size for to reduce memory usage.", "option", "b", int),
-    cutoff=("Limit neighbors to this many earliest rows", "option", "c", int,),
+    cutoff=("Limit neighbors to this many earliest rows", "option", "c", int),
     start=("Index of vectors to start at.", "option", "s", int),
     end=("Index of vectors to stop at.", "option", "e", int),
 )
@@ -32,6 +32,7 @@ def main(
     else:
         import cupy as xp
         import cupy.cuda.device
+
         xp.take_along_axis = take_along_axis
         device = cupy.cuda.device.Device(gpu_id)
         cupy.cuda.get_cublas_handle()
@@ -66,8 +67,8 @@ def main(
         sims = xp.dot(batch, subset.T)
         # Set self-similarities to -inf, so that we don't return them.
         for j in range(size):
-            if i+j < sims.shape[1]:
-                sims[j, i+j] = -xp.inf
+            if i + j < sims.shape[1]:
+                sims[j, i + j] = -xp.inf
         # This used to use argpartition, to do a partial sort...But this ended
         # up being a ratsnest of terrible numpy crap. Just sorting the whole
         # list isn't really slower, and it's much simpler to read.

--- a/sense2vec/sense2vec.py
+++ b/sense2vec/sense2vec.py
@@ -186,7 +186,7 @@ class Sense2Vec(object):
         average_a = numpy.vstack([self[key] for key in keys_a]).mean(axis=0)
         average_b = numpy.vstack([self[key] for key in keys_b]).mean(axis=0)
         return cosine_similarity(average_a, average_b)
-    
+
     def most_similar(
         self,
         keys: Union[Sequence[Union[str, int]], str, int],
@@ -214,8 +214,11 @@ class Sense2Vec(object):
                 rows = self.cache["indices"][key_row, :n]
                 scores = self.cache["scores"][key_row, :n]
                 entries = zip(rows, scores)
-                entries = [(self.strings[self.row2key[r]], score) for r, score in entries
-                            if r in self.row2key]
+                entries = [
+                    (self.strings[self.row2key[r]], score)
+                    for r, score in entries
+                    if r in self.row2key
+                ]
                 return entries
         # Always ask for more because we'll always get the keys themselves
         n = min(len(self.vectors), n + len(keys))

--- a/sense2vec/sense2vec.py
+++ b/sense2vec/sense2vec.py
@@ -5,7 +5,7 @@ from spacy.strings import StringStore
 import numpy
 import srsly
 
-from .util import registry, SimpleFrozenDict
+from .util import registry, cosine_similarity, SimpleFrozenDict
 
 
 class Sense2Vec(object):
@@ -185,14 +185,8 @@ class Sense2Vec(object):
             keys_b = [keys_b]
         average_a = numpy.vstack([self[key] for key in keys_a]).mean(axis=0)
         average_b = numpy.vstack([self[key] for key in keys_b]).mean(axis=0)
-        if average_a.all() == 0 or average_b.all() == 0:
-            return 0.0
-        norm_a = numpy.linalg.norm(average_a)
-        norm_b = numpy.linalg.norm(average_b)
-        if norm_a == norm_b:
-            return 1.0
-        return numpy.dot(average_a, average_b) / (norm_a * norm_b)
-
+        return cosine_similarity(average_a, average_b)
+    
     def most_similar(
         self,
         keys: Union[Sequence[Union[str, int]], str, int],

--- a/sense2vec/util.py
+++ b/sense2vec/util.py
@@ -2,6 +2,7 @@ from typing import Union, List, Tuple, Set
 import re
 from spacy.tokens import Doc, Token, Span
 from spacy.util import filter_spans
+from thinc.neural.util import get_array_module
 import catalogue
 
 try:
@@ -165,6 +166,18 @@ def merge_phrases(doc: Doc) -> Doc:
         for span in spans:
             retokenizer.merge(span)
     return doc
+
+
+def cosine_similarity(vec1, vec2) -> float:
+    """Compute the cosine similarity of two vectors."""
+    if vec1.all() == 0 or vec2.all() == 0:
+        return 0.0
+    xp = get_array_module(vec1)
+    norm1 = xp.linalg.norm(vec1)
+    norm2 = xp.linalg.norm(vec2)
+    if norm1 == norm2:
+        return 1.0
+    return xp.dot(vec1, vec2) / (norm1 * norm2)
 
 
 class SimpleFrozenDict(dict):


### PR DESCRIPTION
Neighbour results are often disappointing if they return a lot of trivial variations of the query, for instance if you just get different casings, or you just get mistaken tags, etc.

This adds two filtering options to cut down on the redundant entries in the vocab. They're applied during the export script, so that we don't have to delete any rows from the vectors table. The names of these settings are currently pretty bad, and I've had trouble describing them concisely.

* `min_freq_ratio`: Let's say we have two keys, `the|DET` and `the|NOUN`. If the frequency of `the|NON` is less than `min_freq_ratio` percent of `the|DET`'s frequency, then we drop `the|NOUN`. We do this for case and tag variations.

* `min_distance`: Map keys together if they share the same lower-case last term, i.e. `split_key(key)[0].split("_")[-1].lower()`. Then we discard any keys that are too similar to the most frequent entry. For instance, if we had `good|ADJ` and `pretty_good|ADJ`, and the distance threshold was 0.8 and their similarity was 0.79, we'd discard the less frequent of the two.

I used `min_freq_ratio=0.01` and `min_distance=0.7` to filter the 2009-2019 Reddit model, and discarded about 15% of the keys.