### PR TITLE
Fix #118

### DIFF
--- a/sense2vec/component.py
+++ b/sense2vec/component.py
@@ -196,7 +196,7 @@ class Sense2VecComponent(object):
         RETURNS (list): A list of other senses.
         """
         key = self.s2v_key(obj)
-        return obj._._s2v.get_other_senses(key)
+        return obj.doc._._s2v.get_other_senses(key)
 
     def to_bytes(self) -> bytes:
         """Serialize the component to a bytestring.


### PR DESCRIPTION
The reference to 'doc' was missing from the s2v extension of the sentence. Now the method _s2v_other_senses_ works. 