### PR TITLE
moved last with output file in scripts/01 parse.py

### DIFF
--- a/scripts/01_parse.py
+++ b/scripts/01_parse.py
@@ -12,9 +12,9 @@ import tqdm
     out_dir=("Path to output directory", "positional", None, str),
     spacy_model=("Name of spaCy model to use", "positional", None, str),
     n_process=("Number of processes (multiprocessing)", "option", "n", int),
-    max_docs=("Maximum docs per batch",  "option", "m", int),
+    max_docs=("Maximum docs per batch", "option", "m", int),
 )
-def main(in_file, out_dir, spacy_model="en_core_web_sm", n_process=1, max_docs=10**6):
+def main(in_file, out_dir, spacy_model="en_core_web_sm", n_process=1, max_docs=10 ** 6):
     """
     Step 1: Parse raw text with spaCy
 
@@ -50,12 +50,13 @@ def main(in_file, out_dir, spacy_model="en_core_web_sm", n_process=1, max_docs=1
                     f.write(doc_bin_bytes)
                 msg.good(f"Saved parsed docs to file", output_file.resolve())
                 doc_bin = DocBin(attrs=["POS", "TAG", "DEP", "ENT_TYPE", "ENT_IOB"])
+        batch_num += 1
+        output_file = output_path / f"{input_path.stem}-{batch_num}.spacy"
+        doc_bin_bytes = doc_bin.to_bytes()
         with output_file.open("wb") as f:
-            batch_num += 1
-            output_file = output_path / f"{input_path.stem}-{batch_num}.spacy"
-            doc_bin_bytes = doc_bin.to_bytes()
             f.write(doc_bin_bytes)
-            msg.good(f"Complete. Saved final parsed docs to file", output_file.resolve())
+        msg.good(f"Complete. Saved final parsed docs to file", output_file.resolve())
+
 
 if __name__ == "__main__":
     plac.call(main)


### PR DESCRIPTION
See discussion on #128 

The last `with output_file` in scripts/01 parse.py is in the wrong place. Moved it to line 56 and fixed indents so that it opens the final `output_file`, rather than throwing an error or opening the second last `output_file`