### PR TITLE
check lowercase when ignore_case=True

### DIFF
--- a/sense2vec/sense2vec.py
+++ b/sense2vec/sense2vec.py
@@ -247,7 +247,7 @@ class Sense2Vec(object):
         result = []
         key = key if isinstance(key, str) else self.strings[key]
         word, orig_sense = self.split_key(key)
-        versions = [word, word.upper(), word.title()] if ignore_case else [word]
+        versions = set([word, word.lower(), word.upper(), word.title()]) if ignore_case else [word]
         for text in versions:
             for sense in self.senses:
                 new_key = self.make_key(text, sense)
@@ -270,7 +270,7 @@ class Sense2Vec(object):
         sense_options = senses or self.senses
         if not sense_options:
             return None
-        versions = [word, word.upper(), word.title()] if ignore_case else [word]
+        versions = set([word, word.lower(), word.upper(), word.title()]) if ignore_case else [word]
         freqs = []
         for text in versions:
             for sense in sense_options:

--- a/sense2vec/tests/test_sense2vec.py
+++ b/sense2vec/tests/test_sense2vec.py
@@ -47,6 +47,8 @@ def test_sense2vec_other_senses():
     assert sorted(others) == ["a|B", "a|C"]
     others = s2v.get_other_senses("b|C")
     assert others == ["b|A"]
+    others = s2v.get_other_senses("B|C")
+    assert others == ["b|A"]
     others = s2v.get_other_senses("c|A")
     assert others == []
 
@@ -57,6 +59,7 @@ def test_sense2vec_best_sense():
     for key, freq in [("a|A", 100), ("a|B", 50), ("a|C", 10), ("b|A", 1), ("B|C", 2)]:
         s2v.add(key, numpy.asarray([4, 2, 2, 2], dtype=numpy.float32), freq)
     assert s2v.get_best_sense("a") == "a|A"
+    assert s2v.get_best_sense("A") == "a|A"
     assert s2v.get_best_sense("b") == "B|C"
     assert s2v.get_best_sense("b", ignore_case=False) == "b|A"
     assert s2v.get_best_sense("c") is None


### PR DESCRIPTION
`get_other_senses` and `get_best_sense` claim to check for lowercase, uppercase, and title case when `ignore_case=True`. However, they only check for the case that's passed in, upper, and title, but don't check for lowercase. This PR fixes this issue so lowercase is explicitly checked as well.

closes #138 