### PR TITLE
Fix broken markdown table

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,12 +192,12 @@ The following attributes are available via the `._` property of `Token` and
 `Span` objects – for example `token._.in_s2v`:
 
 | Name               | Attribute Type | Return Type        | Description                                                                        |
-| ------------------ | -------------- | ------------------ | ---------------------------------------------------------------------------------- | --------------- | ------- |
-| `in_s2v`           | property       | bool               | Whether a key exists in the vector map.                                            |
-| `s2v_key`          | property       | unicode            | The sense2vec key of the given object, e.g. `"duck                                 | NOUN"`.         |
+| ------------------ | -------------- | ------------------ | ---------------------------------------------------------------------------------- |
+| `in_s2v`           | property       | bool               | Whether a key exists in the vector map.                                            |                 
+| `s2v_key`          | property       | unicode            | The sense2vec key of the given object, e.g. `"duck\|NOUN"`.                        |
 | `s2v_vec`          | property       | `ndarray[float32]` | The vector of the given key.                                                       |
 | `s2v_freq`         | property       | int                | The frequency of the given key.                                                    |
-| `s2v_other_senses` | property       | list               | Available other senses, e.g. `"duck                                                | VERB"`for`"duck | NOUN"`. |
+| `s2v_other_senses` | property       | list               | Available other senses, e.g. `"duck\|VERB"` for `"duck\|NOUN"`.                    |
 | `s2v_most_similar` | method         | list               | Get the `n` most similar terms. Returns a list of `((word, sense), score)` tuples. |
 | `s2v_similarity`   | method         | float              | Get the similarity to another `Token` or `Span`.                                   |
 


### PR DESCRIPTION
Escape the pipe symbols in some of the senses. The unescaped pipes had broken the table, although it looks like some markdown processor had also added an extra unnnecessary column to the table.